### PR TITLE
Fix problem with space added at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ## Sublime Text Launcher
 
 ### Introduction
-This (very) small utility provides the means to replace Notepad.exe on Windows with Sublime.
+This small utility provides the means to replace Notepad.exe on Windows with Sublime.
 
-More information about Sublime can be found on [the Sublime website](http://www.sublimetext.com/)
+More information about Sublime Text can be found on [the Sublime Text website](http://www.sublimetext.com/)
 
 ### Installation
 
 Installation is simple:
 
-* Download the ZIP file from the [Downloads](https://github.com/downloads/grumpydev/Sublime-Notepad-Replacement/SublimeLauncher.zip) section. 
-* Extract the ZIP to a temporary folder then copy both of the files from (SublimeLauncher.exe and ReplaceNotepad.bat) it into the same directory as Sublime itself.
+* Download the ZIP file from the [Downloads](https://github.com/downloads/grumpydev/Sublime-Notepad-Replacement/SublimeLauncher.zip) section.
+* Extract the two files in the ZIP (SublimeLauncher.exe and ReplaceNotepad.bat) to the same directory as Sublime Text itself.
 * Run ReplaceNotepad.bat. You will need to "Run as Administrator" if using Vista/Win7.
 
-Now when the system wants to launch Notepad it will launch Sublime instead.
+Now when the system wants to launch Notepad it will launch Sublime Text instead.
 
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ More information about Sublime Text can be found on [the Sublime Text website](h
 
 ### Installation
 
-Installation is simple:
-
 * Download the ZIP file from the [Downloads](https://github.com/downloads/grumpydev/Sublime-Notepad-Replacement/SublimeLauncher.zip) section.
-* Extract the two files in the ZIP (SublimeLauncher.exe and ReplaceNotepad.bat) to the same directory as Sublime Text itself.
+* Extract the three files in the ZIP (SublimeLauncher.exe, ReplaceNotepad.bat and RevertNotepadRedirection.bat) to the same directory as Sublime Text itself.
 * Run ReplaceNotepad.bat. You will need to "Run as Administrator" if using Vista/Win7.
 
 Now when the system wants to launch Notepad it will launch Sublime Text instead.
 
 Enjoy!
+
+### Uninstallation
+* If you ever want to revert changes and return to Notepad, run RevertNotepadRedirection.bat.

--- a/installer/ReplaceNotepad.bat
+++ b/installer/ReplaceNotepad.bat
@@ -1,6 +1,6 @@
 @echo off
 @echo.
-if not exist sublime_text.exe (
+if not exist "%~dp0SublimeLauncher.exe" (
 	echo Warning: Can't find sublime_text.exe. You must put these files in your
 	echo Sublime Text directory before running this file.
 	echo Press enter to continue anyway...

--- a/installer/ReplaceNotepad.bat
+++ b/installer/ReplaceNotepad.bat
@@ -1,4 +1,15 @@
 @echo off
-@echo If you see "ERROR: Access is denied." you need to right click and "Run as Administrator"
+@echo.
+if not exist sublime_text.exe (
+	echo Warning: Can't find sublime_text.exe. You must put these files in your
+	echo Sublime Text directory before running this file.
+	echo Press enter to continue anyway...
+	@echo.
+	pause
+)
+echo If you see "ERROR: Access is denied." then you need to right click and use "Run as Administrator".
+@echo.
+echo Redirecting Notepad.exe to SublimeLauncher.exe...
 reg add "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\notepad.exe" /v "Debugger" /t REG_SZ /d "\"%~dp0SublimeLauncher.exe\" -z" /f
+@echo.
 pause

--- a/installer/RevertNotepadRedirection.bat
+++ b/installer/RevertNotepadRedirection.bat
@@ -1,0 +1,8 @@
+@echo off
+@echo.
+echo If you see "ERROR: Access is denied." then you need to right click and use "Run as Administrator".
+@echo.
+echo Reverting changes to Notepad.exe redirection...
+reg delete "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\notepad.exe" /f
+@echo.
+pause

--- a/src/Sublime Launcher/SublimeLauncher/SublimeLauncher.cpp
+++ b/src/Sublime Launcher/SublimeLauncher/SublimeLauncher.cpp
@@ -28,10 +28,11 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 		{
 			if (argumentsPassed == false)
 				wcscat(arguments, L"\"");
+			else
+				wcscat(arguments, L" ");
 
 			argumentsPassed = true;
 			wcscat(arguments, __wargv[i]);
-			wcscat(arguments, L" ");
 		}
 	}
 


### PR DESCRIPTION
Changes:
- Fixed issue with space being added at the end that prevented automatic syntax highlighting and caused other issues (e.g. building with Ctrl+B).
- Made the installer smarter.
- Added bat file to revert notepad redirection.

Fixes issue 1, issue 2 and issue 3.

Please note that since Github has deprecated the downloads section, you have to host the new version in the repository. I suggest creating an "assets" directory and put the new zip there.

Thank you.
